### PR TITLE
Add AppsFlyer Swift demo

### DIFF
--- a/AppsFlyerDemo/AppDelegate.swift
+++ b/AppsFlyerDemo/AppDelegate.swift
@@ -1,0 +1,33 @@
+import UIKit
+import AppsFlyerLib
+
+class AppDelegate: NSObject, UIApplicationDelegate, AppsFlyerLibDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // TODO: Replace with your own AppsFlyer dev key and Apple App ID
+        AppsFlyerLib.shared().appsFlyerDevKey = "<AF_DEV_KEY>"
+        AppsFlyerLib.shared().appleAppID = "<APPLE_APP_ID>"
+        AppsFlyerLib.shared().delegate = self
+        AppsFlyerLib.shared().isDebug = true
+        AppsFlyerLib.shared().start()
+        return true
+    }
+
+    func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        AppsFlyerLib.shared().handleOpen(url, options: options)
+        return true
+    }
+
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        AppsFlyerLib.shared().continue(userActivity, restorationHandler: nil)
+        return true
+    }
+
+    // MARK: - AppsFlyerLibDelegate
+    func onConversionDataSuccess(_ conversionInfo: [AnyHashable : Any]) {
+        print("Conversion data: \(conversionInfo)")
+    }
+
+    func onConversionDataFail(_ error: Error) {
+        print("Conversion data error: \(error)")
+    }
+}

--- a/AppsFlyerDemo/AppsFlyerDemoApp.swift
+++ b/AppsFlyerDemo/AppsFlyerDemoApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+import AppsFlyerLib
+
+@main
+struct AppsFlyerDemoApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/AppsFlyerDemo/ContentView.swift
+++ b/AppsFlyerDemo/ContentView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Text("Hello, AppsFlyer!")
+                .padding()
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/AppsFlyerDemo/Info.plist
+++ b/AppsFlyerDemo/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# chatgpttest
+# AppsFlyer iOS Demo
+
+This repository contains a very small SwiftUI iOS app demonstrating how to integrate the AppsFlyer SDK using Swift Package Manager.
+
+## Getting Started
+
+1. Open Xcode and create a new **iOS App** project, or use the files in `AppsFlyerDemo/` inside an existing project.
+2. Replace the generated files with the ones from this repository.
+3. Add the AppsFlyer SDK using Xcode's Swift Package Manager support:
+   - In Xcode, go to **File > Add Packages...**
+   - Enter `https://github.com/AppsFlyerSDK/AppsFlyerFramework` as the package URL and follow the prompts.
+4. Update `AppDelegate.swift` with your own AppsFlyer dev key and Apple app ID.
+5. Build and run on an iPhone simulator or device.
+
+The `ContentView` displays a simple label. AppsFlyer is initialized in `AppDelegate` at application launch.


### PR DESCRIPTION
## Summary
- create a minimal SwiftUI app that integrates the AppsFlyer SDK
- document how to add the SDK via Swift Package Manager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6880bc9bc464832c9dc859e08d8a35cf